### PR TITLE
Reject leading-dash git revisions in detect_changes range

### DIFF
--- a/internal/tools/detect_changes.go
+++ b/internal/tools/detect_changes.go
@@ -27,7 +27,13 @@ func gitDiffArgs(scope, diffRange string) []string {
 		if diffRange != "" {
 			parts := strings.SplitN(diffRange, "..", 2)
 			if len(parts) == 2 {
+				if !safeGitRev(parts[0]) || !safeGitRev(parts[1]) {
+					return nil
+				}
 				return []string{"diff", "--name-only", parts[0], parts[1]}
+			}
+			if !safeGitRev(diffRange) {
+				return nil
 			}
 			return []string{"diff", "--name-only", diffRange + "~1", diffRange}
 		}
@@ -35,6 +41,17 @@ func gitDiffArgs(scope, diffRange string) []string {
 	default: // "unstaged" or empty
 		return []string{"diff", "--name-only"}
 	}
+}
+
+// safeGitRev reports whether s can be passed to git as a revision argument.
+// Empty pieces and pieces starting with "-" are rejected so a range value
+// cannot inject git options.
+func safeGitRev(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.HasPrefix(s, "-") {
+		return false
+	}
+	return true
 }
 
 // filterChangedFiles keeps only files that exist on disk and have a recognized
@@ -105,6 +122,9 @@ func HandleDetectChanges(ctx context.Context, client *lsp.LSPClient, args map[st
 
 	// Run git diff.
 	gitArgs := gitDiffArgs(scope, diffRange)
+	if gitArgs == nil {
+		return types.ErrorResult("invalid range: revisions must not start with -"), nil
+	}
 	cmd := exec.CommandContext(ctx, "git", gitArgs...)
 	cmd.Dir = workspaceRoot
 	var stdout, stderr bytes.Buffer

--- a/internal/tools/detect_changes_test.go
+++ b/internal/tools/detect_changes_test.go
@@ -39,6 +39,26 @@ func TestGitDiffArgs(t *testing.T) {
 	}
 }
 
+func TestGitDiffArgsRejectsLeadingDash(t *testing.T) {
+	cases := []struct {
+		scope, rng string
+		wantNil    bool
+	}{
+		{"committed", "--output=/tmp/x..HEAD", true},
+		{"committed", "HEAD..--output=/tmp/x", true},
+		{"committed", "-HEAD", true},
+		{"committed", "HEAD~1..HEAD", false},
+		{"committed", "HEAD", false},
+		{"committed", "", false},
+	}
+	for _, c := range cases {
+		got := gitDiffArgs(c.scope, c.rng)
+		if (got == nil) != c.wantNil {
+			t.Fatalf("gitDiffArgs(%q, %q) = %v, wantNil=%v", c.scope, c.rng, got, c.wantNil)
+		}
+	}
+}
+
 func TestFilterChangedFiles(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
`detect_changes` takes MCP arg `range`, splits on `..`, and passes both sides to `git diff --name-only`. A value like `--output=<path>..<rev>` becomes `git diff --name-only --output=<path> <rev>`.

Reject any range piece that is empty or starts with `-` before exec.

*AI-assisted.*